### PR TITLE
Fixed logic in submitAndDestroy()

### DIFF
--- a/spark-janelia-lsf
+++ b/spark-janelia-lsf
@@ -277,7 +277,7 @@ def submitAndDestroy(jobID, driverslots, sparksubargs):
     drivercomplete = False
     while not drivercomplete:
         driverstat = subprocess.check_output("bjobs -noheader -o 'STAT' {}".format(driverjobID), universal_newlines=True, shell=True)
-        if str(driverstat) is "EXIT" or "DONE":
+        if str(driverstat) in ("EXIT", "DONE"):
             drivercomplete = True
         time.sleep(30)
     destroy(jobID)


### PR DESCRIPTION
This fixes a little logic error in `submitAndDestroy()`.

The condition in this `if` statement will always evaluate to `"DONE"`.  Since that's a non-empty string, the `if` statement is satisfied, and thus the loop will always exit after just a single iteration.

(I haven't tried the `lsd` command yet myself, but I noticed this problem while reading over the code.)